### PR TITLE
Fix invalid version numbers in Go and C# projects

### DIFF
--- a/hello_cs/hello_cs.csproj
+++ b/hello_cs/hello_cs.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/hello_go/go.mod
+++ b/hello_go/go.mod
@@ -1,3 +1,3 @@
 module example.com/hello
 
-go 1.25.5
+go 1.23


### PR DESCRIPTION
- Update Go version from 1.25.5 to 1.23 in hello_go/go.mod
- Update .NET version from net10.0 to net9.0 in hello_cs/hello_cs.csproj

These invalid versions were causing the CodeQL workflow to fail during autobuild.

Fixes #1